### PR TITLE
TASK-23: secure media file access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Portfolio Website Agent Workflow
+
+## Scope
+
+- This repository contains the NestJS backend for the Portfolio Website project.
+- The sibling frontend repository is `/Users/kotyarya/Dev/portfol`.
+- Notion project `Portfolio Website` and its task database are the source of truth for priorities and status.
+
+## Task workflow
+
+1. Select the highest-priority unblocked task: Critical, High, Normal, then Low. Prefer security, production blockers, SEO, and dependency-unblocking work.
+2. Before editing, tell the user which task was selected, why, the implementation idea, risks, and verification plan.
+3. Move the Notion task to `В работе` and add a short progress note.
+4. Use one branch per task named `codex/TASK-ID-short-description`.
+5. Keep the change focused. Preserve unrelated user edits and never stage them silently.
+6. Run the relevant checks. For backend changes, normally run `npm test -- --runInBand`, `npm run build`, and `npm run lint -- --no-fix`.
+7. Self-review the final diff for correctness, security, regressions, and missing tests.
+8. Commit with the Task ID, push the branch, and open a draft pull request.
+9. Add the pull request URL and verification summary to Notion, then move the task to `Code Review`.
+10. Mark `Definition of Done` only after all acceptance criteria are verified.
+
+## Safety boundaries
+
+- Do not merge pull requests or deploy production without explicit user approval.
+- Ask before adding production dependencies, changing secrets, running migrations, or performing destructive operations.
+- Never commit credentials, `.env` contents, generated build output, or unrelated IDE files.
+- If blocked, record the reason in Notion, set `Заблокировано`, and continue with another unblocked task when appropriate.
+
+## Code expectations
+
+- Add regression tests for bug fixes and security changes.
+- Prefer explicit validation at public boundaries and fail closed.
+- Use NestJS exceptions for intentional HTTP errors.
+- Keep TypeScript types explicit at external boundaries and follow the existing formatter and linter configuration.

--- a/src/media/media.service.spec.ts
+++ b/src/media/media.service.spec.ts
@@ -1,0 +1,78 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PassThrough, Writable } from 'node:stream';
+import { finished } from 'node:stream/promises';
+import { Response } from 'express';
+import { MediaService } from './media.service';
+
+describe('MediaService', () => {
+  let mediaPath: string;
+  let service: MediaService;
+
+  beforeEach(() => {
+    mediaPath = mkdtempSync(join(tmpdir(), 'portfolio-media-'));
+    service = new MediaService();
+    Object.defineProperty(service, 'mediaPath', { value: mediaPath });
+  });
+
+  afterEach(() => {
+    rmSync(mediaPath, { recursive: true, force: true });
+  });
+
+  it('streams a regular file from the media directory', async () => {
+    writeFileSync(join(mediaPath, 'profile.txt'), 'portfolio');
+    const response = new PassThrough() as PassThrough & Response & Writable;
+    const setHeader = jest.fn();
+    const chunks: Buffer[] = [];
+    response.setHeader = setHeader;
+    response.on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+
+    service.getFile('profile.txt', response);
+    await finished(response);
+
+    expect(Buffer.concat(chunks).toString()).toBe('portfolio');
+    expect(setHeader).toHaveBeenCalledWith('Content-Type', 'text/plain');
+    expect(setHeader).toHaveBeenCalledWith('Content-Length', '9');
+  });
+
+  it.each([
+    '../secret.txt',
+    '..\\secret.txt',
+    '..%2Fsecret.txt',
+    '%2e%2e%2fsecret.txt',
+    '%252e%252e%252fsecret.txt',
+    '%00secret.txt',
+  ])('rejects an unsafe file name: %s', (fileName) => {
+    expect(() => service.getFile(fileName, createResponse())).toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('rejects a symlink that resolves outside the media directory', () => {
+    const outsidePath = join(mediaPath, '..', 'portfolio-secret.txt');
+    writeFileSync(outsidePath, 'secret');
+    symlinkSync(outsidePath, join(mediaPath, 'link.txt'));
+
+    try {
+      expect(() => service.getFile('link.txt', createResponse())).toThrow(
+        BadRequestException,
+      );
+    } finally {
+      rmSync(outsidePath, { force: true });
+    }
+  });
+
+  it('returns not found for a missing file', () => {
+    expect(() => service.getFile('missing.txt', createResponse())).toThrow(
+      NotFoundException,
+    );
+  });
+});
+
+function createResponse(): Response & Writable {
+  const response = new PassThrough() as PassThrough & Response & Writable;
+  response.setHeader = jest.fn();
+  return response;
+}

--- a/src/media/media.service.ts
+++ b/src/media/media.service.ts
@@ -1,29 +1,92 @@
-import {Injectable, NotFoundException} from '@nestjs/common';
-import {join} from 'path';
-import {createReadStream, existsSync} from 'fs';
-import {Writable} from 'stream';
-import {Response} from 'express';
-import {statSync} from "node:fs";
-import {lookup as getMimeType} from 'mime-types';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { basename, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { createReadStream, existsSync, realpathSync, statSync } from 'node:fs';
+import { Writable } from 'node:stream';
+import { Response } from 'express';
+import { lookup as getMimeType } from 'mime-types';
 
 @Injectable()
 export class MediaService {
-    private readonly mediaPath = join(__dirname, '..', '..', 'static');
+  private readonly mediaPath = join(__dirname, '..', '..', 'static');
 
-    getFile(fileName: string, res: Response & Writable): void {
-        const path = join(this.mediaPath, fileName);
+  getFile(fileName: string, res: Response & Writable): void {
+    const filePath = this.resolveFilePath(fileName);
+    const mimeType = getMimeType(filePath) || 'application/octet-stream';
+    const { size } = statSync(filePath);
 
-        if (!existsSync(path)) {
-            throw new NotFoundException('File not found');
+    res.setHeader('Content-Type', mimeType);
+    res.setHeader('Content-Length', size.toString());
+
+    const stream = createReadStream(filePath);
+    stream.pipe(res);
+  }
+
+  private resolveFilePath(fileName: string): string {
+    const decodedFileName = this.decodeFileName(fileName);
+
+    if (
+      decodedFileName.length === 0 ||
+      decodedFileName === '.' ||
+      decodedFileName === '..' ||
+      decodedFileName.includes('\0') ||
+      decodedFileName.includes('/') ||
+      decodedFileName.includes('\\') ||
+      basename(decodedFileName) !== decodedFileName
+    ) {
+      throw new BadRequestException('Invalid file name');
+    }
+
+    const mediaRoot = realpathSync(resolve(this.mediaPath));
+    const candidatePath = resolve(mediaRoot, decodedFileName);
+    this.assertWithinMediaRoot(mediaRoot, candidatePath);
+
+    if (!existsSync(candidatePath)) {
+      throw new NotFoundException('File not found');
+    }
+
+    const realFilePath = realpathSync(candidatePath);
+    this.assertWithinMediaRoot(mediaRoot, realFilePath);
+
+    if (!statSync(realFilePath).isFile()) {
+      throw new NotFoundException('File not found');
+    }
+
+    return realFilePath;
+  }
+
+  private decodeFileName(fileName: string): string {
+    let decodedFileName = fileName;
+
+    try {
+      for (let pass = 0; pass < 5; pass += 1) {
+        const nextValue = decodeURIComponent(decodedFileName);
+
+        if (nextValue === decodedFileName) {
+          return decodedFileName;
         }
 
-        const mimeType = getMimeType(path) || 'application/octet-stream';
-        const {size} = statSync(path);
-
-        res.setHeader('Content-Type', mimeType);
-        res.setHeader('Content-Length', size.toString());
-
-        const stream = createReadStream(path);
-        stream.pipe(res);
+        decodedFileName = nextValue;
+      }
+    } catch {
+      throw new BadRequestException('Invalid file name');
     }
+
+    throw new BadRequestException('Invalid file name');
+  }
+
+  private assertWithinMediaRoot(mediaRoot: string, filePath: string): void {
+    const relativePath = relative(mediaRoot, filePath);
+
+    if (
+      relativePath === '..' ||
+      relativePath.startsWith(`..${sep}`) ||
+      isAbsolute(relativePath)
+    ) {
+      throw new BadRequestException('Invalid file name');
+    }
+  }
 }

--- a/src/types/mime-types.d.ts
+++ b/src/types/mime-types.d.ts
@@ -1,0 +1,3 @@
+declare module 'mime-types' {
+  export function lookup(path: string): string | false;
+}


### PR DESCRIPTION
## Что изменено

- имена файлов декодируются и валидируются до обращения к файловой системе;
- запрещены traversal-последовательности, слеши, обратные слеши и нулевые байты;
- реальный путь обязан оставаться внутри директории `static`, включая защиту от симлинков наружу;
- директории и отсутствующие файлы не выдаются;
- добавлены постоянные правила работы Codex для backend-репозитория.

## Почему

Публичный endpoint `/media/:fileName` строил путь без проверки границ, поэтому специально сформированное имя могло попытаться прочитать файл за пределами разрешённой директории.

## Проверка

- `npm test -- --runInBand` — 9/9 тестов прошли;
- `npm run build` — успешно;
- `npm run lint -- --no-fix` — 0 ошибок, одна существующая warning в `src/main.ts` вне этой задачи;
- покрыты обычный файл, `../`, обратный слеш, URL-кодирование, двойное URL-кодирование, нулевой байт, симлинк наружу и отсутствующий файл.

Notion: TASK-23
