### PR TITLE
TASK-62: fail closed on missing API key

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { SkillsModule } from './skills/skills.module';
 import { ConfigModule } from '@nestjs/config';
 import { ApiKeyGuard } from './common/api-key.guard';
 import { ContactModule } from './contact/contact.module';
+import { validateEnvironment } from './config/env.validation';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { ContactModule } from './contact/contact.module';
     SkillsModule,
     ConfigModule.forRoot({
       isGlobal: true,
+      validate: validateEnvironment,
     }),
     ContactModule,
   ],

--- a/src/common/api-key.guard.spec.ts
+++ b/src/common/api-key.guard.spec.ts
@@ -1,0 +1,103 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Reflector } from '@nestjs/core';
+import { Request } from 'express';
+import { ApiKeyGuard } from './api-key.guard';
+
+describe('ApiKeyGuard', () => {
+  let reflector: Reflector;
+
+  beforeEach(() => {
+    reflector = new Reflector();
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+  });
+
+  it('rejects a request when the server API key is missing', () => {
+    const guard = createGuard(new ConfigService({}), reflector);
+
+    expect(() => guard.canActivate(createContext())).toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('rejects a request when the server API key is empty', () => {
+    const guard = createGuard(new ConfigService({ API_KEY: '   ' }), reflector);
+
+    expect(() => guard.canActivate(createContext('   '))).toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('rejects a request when the client API key is missing', () => {
+    const guard = createGuard(
+      new ConfigService({ API_KEY: 'valid-key' }),
+      reflector,
+    );
+
+    expect(() => guard.canActivate(createContext())).toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('rejects a request with the wrong API key', () => {
+    const guard = createGuard(
+      new ConfigService({ API_KEY: 'valid-key' }),
+      reflector,
+    );
+
+    expect(() => guard.canActivate(createContext('wrong-key'))).toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('rejects multiple API key header values', () => {
+    const guard = createGuard(
+      new ConfigService({ API_KEY: 'valid-key' }),
+      reflector,
+    );
+
+    expect(() =>
+      guard.canActivate(createContext(['valid-key', 'second-key'])),
+    ).toThrow(UnauthorizedException);
+  });
+
+  it('allows a request with the valid API key', () => {
+    const guard = createGuard(
+      new ConfigService({ API_KEY: 'valid-key' }),
+      reflector,
+    );
+
+    expect(guard.canActivate(createContext('valid-key'))).toBe(true);
+  });
+
+  it('allows a public route without reading an API key', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(true);
+    const configService = new ConfigService({});
+    const configSpy = jest.spyOn(configService, 'get');
+    const guard = createGuard(configService, reflector);
+
+    expect(guard.canActivate(createContext())).toBe(true);
+    expect(configSpy).not.toHaveBeenCalled();
+  });
+});
+
+function createGuard(
+  configService: ConfigService,
+  reflector: Reflector,
+): ApiKeyGuard {
+  return new ApiKeyGuard(configService, reflector);
+}
+
+function createContext(apiKey?: string | string[]): ExecutionContext {
+  const request = {
+    headers: apiKey === undefined ? {} : { 'x-api-key': apiKey },
+  } as Request;
+
+  return {
+    getClass: jest.fn(),
+    getHandler: jest.fn(),
+    switchToHttp: () => ({
+      getRequest: () => request,
+    }),
+  } as unknown as ExecutionContext;
+}

--- a/src/common/api-key.guard.ts
+++ b/src/common/api-key.guard.ts
@@ -17,11 +17,6 @@ export class ApiKeyGuard implements CanActivate {
   ) {}
 
   canActivate(context: ExecutionContext): boolean {
-    const request = context.switchToHttp().getRequest<Request>();
-    const apiKey = request.headers['x-api-key'];
-
-    const validKey = this.configService.get<string>('API_KEY');
-
     const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
       context.getHandler(),
       context.getClass(),
@@ -29,7 +24,16 @@ export class ApiKeyGuard implements CanActivate {
 
     if (isPublic) return true;
 
-    if (apiKey !== validKey) {
+    const request = context.switchToHttp().getRequest<Request>();
+    const apiKey = request.headers['x-api-key'];
+    const validKey = this.configService.get<string>('API_KEY');
+
+    if (
+      typeof validKey !== 'string' ||
+      validKey.trim().length === 0 ||
+      typeof apiKey !== 'string' ||
+      apiKey !== validKey
+    ) {
       throw new UnauthorizedException('Invalid API key');
     }
 

--- a/src/config/env.validation.spec.ts
+++ b/src/config/env.validation.spec.ts
@@ -1,0 +1,60 @@
+import { validateEnvironment } from './env.validation';
+
+const validConfiguration = {
+  API_KEY: 'test-api-key',
+  DATABASE_URL: 'postgresql://user:password@localhost:5432/portfolio',
+  MAILER_USER: 'owner@example.com',
+  MAILER_PASS: 'test-mailer-password',
+};
+
+describe('validateEnvironment', () => {
+  it.each(Object.keys(validConfiguration))(
+    'rejects a missing %s variable',
+    (variableName) => {
+      const configuration = { ...validConfiguration } as Record<
+        string,
+        unknown
+      >;
+      delete configuration[variableName];
+
+      expect(() => validateEnvironment(configuration)).toThrow(variableName);
+    },
+  );
+
+  it.each(Object.keys(validConfiguration))(
+    'rejects an empty %s variable',
+    (variableName) => {
+      expect(() =>
+        validateEnvironment({
+          ...validConfiguration,
+          [variableName]: '   ',
+        }),
+      ).toThrow(variableName);
+    },
+  );
+
+  it('returns a valid configuration unchanged', () => {
+    expect(validateEnvironment(validConfiguration)).toBe(validConfiguration);
+  });
+
+  it('does not include secret values in its error', () => {
+    let validationError: unknown;
+
+    try {
+      validateEnvironment({
+        ...validConfiguration,
+        API_KEY: '',
+      });
+    } catch (error) {
+      validationError = error;
+    }
+
+    expect(validationError).toBeInstanceOf(Error);
+    expect((validationError as Error).message).toBe(
+      'Missing or empty required environment variables: API_KEY',
+    );
+    expect((validationError as Error).message).not.toContain(
+      validConfiguration.MAILER_PASS,
+    );
+  });
+});

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -1,0 +1,23 @@
+const REQUIRED_ENVIRONMENT_VARIABLES = [
+  'API_KEY',
+  'DATABASE_URL',
+  'MAILER_USER',
+  'MAILER_PASS',
+] as const;
+
+export function validateEnvironment(
+  configuration: Record<string, unknown>,
+): Record<string, unknown> {
+  const missingVariables = REQUIRED_ENVIRONMENT_VARIABLES.filter((key) => {
+    const value = configuration[key];
+    return typeof value !== 'string' || value.trim().length === 0;
+  });
+
+  if (missingVariables.length > 0) {
+    throw new Error(
+      `Missing or empty required environment variables: ${missingVariables.join(', ')}`,
+    );
+  }
+
+  return configuration;
+}


### PR DESCRIPTION
## Что изменено

- добавлена стартовая валидация обязательных `API_KEY`, `DATABASE_URL`, `MAILER_USER`, `MAILER_PASS`;
- приложение завершает запуск с ошибкой, если переменная отсутствует или пуста;
- `ApiKeyGuard` теперь явно отклоняет запрос при отсутствующем/пустом серверном ключе, отсутствующем header, массиве значений или неверном ключе;
- публичные endpoints продолжают обходить API key guard;
- сообщения валидации содержат только названия переменных и не раскрывают секретные значения.

## Почему

Раньше отсутствующий `API_KEY` мог привести к сравнению `undefined === undefined` и разрешить защищённый запрос без ключа.

## Проверка

- `npm test -- --runInBand` — 26/26 тестов прошли;
- `npm run build` — успешно;
- `npm run lint -- --no-fix` — 0 ошибок, одна существующая warning в `src/main.ts` вне TASK-62;
- локальный `.env` игнорируется Git и содержит имена всех четырёх обязательных переменных; значения не читались и не выводились.

Notion: TASK-62
